### PR TITLE
feat(users): add user notification and email actions in UserResource

### DIFF
--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -4,7 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\UserResource\Pages;
 use App\Models\User;
-use App\Notifications\TestMailNotification;
+use App\Notifications\UserMessageNotification;
 use Filament\Facades\Filament;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -14,11 +14,9 @@ use Filament\Resources\Resource;
 use Filament\Support\Colors\Color;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Notification as LaravelNotification;
 use Illuminate\Support\Str;
-use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
-use Throwable;
 
 class UserResource extends Resource
 {
@@ -95,10 +93,11 @@ class UserResource extends Resource
                     ->copyable()
                     ->copyMessage('Email address copied')
                     ->copyMessageDuration(1500),
-                Tables\Columns\BooleanColumn::make('email_verified_at')
+                Tables\Columns\IconColumn::make('email_verified_at')
                     ->label('Verified')
+                    ->boolean()
                     ->sortable()
-                    ->toggleable(isToggledHiddenByDefault: false),
+                    ->toggleable(),
                 Tables\Columns\TextColumn::make('roles.name')
                     ->label('Role')
                     ->badge()
@@ -132,19 +131,15 @@ class UserResource extends Resource
                     ->color(Color::hex('#ec8200'))
                     ->icon('heroicon-o-shield-check')
                     ->action(function (User $user) {
-                        // $notification = new VerifyEmail;
-                        // $notification->toMail($user);
-                        // $user->sendEmailVerificationNotification();
                         $notification = app(VerifyEmail::class);
                         $notification->url = Filament::getVerifyEmailUrl($user);
                         $user->notify($notification);
                         Notification::make()
                             ->title('Email verification link sent')
-                            ->body('Email verification link sent to ' . $user->email .
-                                '<br>' . $notification->url)
+                            ->body('Email verification link sent to ' . $user->email . '<br>' . $notification->url)
                             ->success()
                             ->icon('heroicon-o-shield-check')
-                            ->iconColor('primery')
+                            ->iconColor('primary')
                             ->persistent()
                             ->send();
                     }),
@@ -156,105 +151,161 @@ class UserResource extends Resource
                     ->icon('heroicon-o-check')
                     ->action(function (User $user) {
                         $user->markEmailAsVerified();
-                        // $user->email_verified_at = now();
-                        // $user->save();
                     }),
-                Tables\Actions\Action::make('send_test_email')
-                    ->label('Send test email')
-                    ->icon('heroicon-o-paper-airplane')
+                Tables\Actions\Action::make('send_db_notice')
+                    ->label('Notify')
+                    ->button()
+                    ->tooltip('Send a database notification to this user')
+                    ->color('gray')
+                    ->icon('heroicon-o-bell')
+                    ->form([
+                        Forms\Components\TextInput::make('subject')
+                            ->label('Subject')
+                            ->required()
+                            ->maxLength(150),
+                        Forms\Components\RichEditor::make('body')
+                            ->label('Message')
+                            ->toolbarButtons([
+                                'attachFiles',
+                                'blockquote',
+                                'bold',
+                                'bulletList',
+                                'codeBlock',
+                                'h1',
+                                'h2',
+                                'h3',
+                                'italic',
+                                'link',
+                                'orderedList',
+                                'redo',
+                                'strike',
+                                'underline',
+                                'undo',
+                            ])
+                            ->fileAttachmentsDisk('public')
+                            ->fileAttachmentsDirectory('editor-attachments')
+                            ->fileAttachmentsVisibility('public')
+                            ->disableGrammarly()
+                            ->columnSpanFull()
+                            ->required(),
+                    ])
+                    ->action(function (User $record, array $data): void {
+                        $record->notify(new UserMessageNotification(
+                            subject: (string)$data['subject'],
+                            body: (string)$data['body'],
+                            channels: ['database'],
+                        ));
+
+                        Notification::make()
+                            ->title('Notification created')
+                            ->body('A database notification was created for ' . $record->email)
+                            ->success()
+                            ->send();
+                    }),
+                Tables\Actions\Action::make('send_email')
+                    ->label('Send Email')
+                    ->button()
+                    ->tooltip('Send an email to this user')
                     ->color('primary')
-                    ->requiresConfirmation()
-                    ->action(function (User $record): void {
-                        $config = self::getMailDiagnosticInfo();
+                    ->icon('heroicon-o-envelope')
+                    ->form([
+                        Forms\Components\TextInput::make('subject')
+                            ->label('Subject')
+                            ->required()
+                            ->maxLength(150),
+                        Forms\Components\RichEditor::make('body')
+                            ->label('Message')
+                            ->toolbarButtons([
+                                'attachFiles',
+                                'blockquote',
+                                'bold',
+                                'bulletList',
+                                'codeBlock',
+                                'h1',
+                                'h2',
+                                'h3',
+                                'italic',
+                                'link',
+                                'orderedList',
+                                'redo',
+                                'strike',
+                                'underline',
+                                'undo',
+                            ])
+                            ->fileAttachmentsDisk('public')
+                            ->fileAttachmentsDirectory('editor-attachments')
+                            ->fileAttachmentsVisibility('public')
+                            ->disableGrammarly()
+                            ->columnSpanFull()
+                            ->required(),
+                    ])
+                    ->action(function (User $record, array $data): void {
+                        LaravelNotification::sendNow($record, new UserMessageNotification(
+                            subject: (string)$data['subject'],
+                            body: (string)$data['body'],
+                            channels: ['mail'],
+                        ));
 
-                        // Probe SMTP connectivity first to avoid long timeouts in UI.
-                        $portsToProbe = array_values(array_unique(array_filter([
-                            (int)($config['port'] ?? 0),
-                            2525,
-                            465,
-                            587,
-                        ])));
-                        $probe = self::smtpProbe((string)$config['host'], $portsToProbe, 2.0);
-
-                        $configuredPort = (int)($config['port'] ?? 0);
-                        $configuredReachable = $configuredPort > 0 && ($probe['ports'][$configuredPort]['ok'] ?? false) === true;
-
-                        if (!$configuredReachable) {
-                            $hints = self::buildMailHints($config, $probe);
-
-                            Log::warning('SMTP probe indicates configured host:port is unreachable.', [
-                                'mail' => $config,
-                                'probe' => $probe,
-                                'user_id' => $record->id,
-                            ]);
-
-                            Notification::make()
-                                ->title('Mail connection unreachable')
-                                ->body('Could not reach the configured SMTP endpoint before sending. Please verify your SendGrid SMTP settings.'
-                                    . '<br>' . self::formatMailDiagnosticInfo($config)
-                                    . '<br>' . self::formatProbe($probe)
-                                    . ($hints !== '' ? '<br>' . $hints : ''))
-                                ->danger()
-                                ->persistent()
-                                ->send();
-
-                            return;
-                        }
-
-                        try {
-                            LaravelNotification::sendNow($record, new TestMailNotification($record));
-
-                            Notification::make()
-                                ->title('Email dispatched')
-                                ->body('A test email was dispatched to ' . $record->email
-                                    . '<br>' . self::formatMailDiagnosticInfo($config)
-                                    . '<br>' . self::formatProbe($probe))
-                                ->success()
-                                ->send();
-                        } catch (TransportExceptionInterface $e) {
-                            Log::error('SMTP transport error during test mail.', [
-                                'exception' => $e,
-                                'mail' => $config,
-                                'probe' => $probe,
-                                'user_id' => $record->id,
-                            ]);
-
-                            $hints = self::buildMailHints($config, $probe);
-
-                            Notification::make()
-                                ->title('Mail connection failed')
-                                ->body('Could not connect to the SMTP server. Please verify your SendGrid SMTP settings.'
-                                    . '<br>' . self::formatMailDiagnosticInfo($config)
-                                    . '<br>' . self::formatProbe($probe)
-                                    . ($hints !== '' ? '<br>' . $hints : ''))
-                                ->danger()
-                                ->persistent()
-                                ->send();
-                        } catch (Throwable $e) {
-                            Log::error('Unexpected error during test mail.', [
-                                'exception' => $e,
-                                'mail' => $config,
-                                'probe' => $probe,
-                                'user_id' => $record->id,
-                            ]);
-
-                            $hints = self::buildMailHints($config, $probe);
-
-                            Notification::make()
-                                ->title('Mail error')
-                                ->body('An unexpected error occurred while sending the test email.'
-                                    . '<br>' . self::formatMailDiagnosticInfo($config)
-                                    . '<br>' . self::formatProbe($probe)
-                                    . ($hints !== '' ? '<br>' . $hints : ''))
-                                ->danger()
-                                ->persistent()
-                                ->send();
-                        }
+                        Notification::make()
+                            ->title('Email sent')
+                            ->body('Email sent to ' . $record->email)
+                            ->success()
+                            ->send();
                     }),
-
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\BulkAction::make('bulk_send_email')
+                        ->label('Send Email')
+                        ->icon('heroicon-o-envelope')
+                        ->color('primary')
+                        ->requiresConfirmation()
+                        ->form([
+                            Forms\Components\TextInput::make('subject')
+                                ->label('Subject')
+                                ->required()
+                                ->maxLength(150),
+                            Forms\Components\RichEditor::make('body')
+                                ->label('Message')
+                                ->toolbarButtons([
+                                    'attachFiles',
+                                    'blockquote',
+                                    'bold',
+                                    'bulletList',
+                                    'codeBlock',
+                                    'h1',
+                                    'h2',
+                                    'h3',
+                                    'italic',
+                                    'link',
+                                    'orderedList',
+                                    'redo',
+                                    'strike',
+                                    'underline',
+                                    'undo',
+                                ])
+                                ->fileAttachmentsDisk('public')
+                                ->fileAttachmentsDirectory('editor-attachments')
+                                ->fileAttachmentsVisibility('public')
+                                ->disableGrammarly()
+                                ->columnSpanFull()
+                                ->required(),
+                        ])
+                        ->action(function (Collection $records, array $data): void {
+                            $notification = new UserMessageNotification(
+                                subject: (string)$data['subject'],
+                                body: (string)$data['body'],
+                                channels: ['mail'],
+                            );
+
+                            LaravelNotification::sendNow($records, $notification);
+
+                            Notification::make()
+                                ->title('Emails sent')
+                                ->body('Email sent to ' . $records->count() . ' users')
+                                ->success()
+                                ->send();
+                        }),
                     Tables\Actions\DeleteBulkAction::make(),
                 ]),
             ]);
@@ -274,174 +325,5 @@ class UserResource extends Resource
             'create' => Pages\CreateUser::route('/create'),
             'edit' => Pages\EditUser::route('/{record}/edit'),
         ];
-    }
-
-    protected static function getMailDiagnosticInfo(): array
-    {
-        $default = (string)(config('mail.default') ?? 'smtp');
-        $mailerKey = $default !== '' ? $default : 'smtp';
-
-        $transport = (string)(config("mail.mailers.$mailerKey.transport") ?? '');
-        $host = (string)(config("mail.mailers.$mailerKey.host") ?? config('mail.mailers.smtp.host'));
-        $port = (int)(config("mail.mailers.$mailerKey.port") ?? (int)(config('mail.mailers.smtp.port') ?? 0));
-        $encryption = (string)(config("mail.mailers.$mailerKey.encryption") ?? config('mail.mailers.smtp.encryption'));
-        $username = (string)(config("mail.mailers.$mailerKey.username") ?? config('mail.mailers.smtp.username'));
-        $fromAddress = (string)(config('mail.from.address') ?? '');
-        $fromName = (string)(config('mail.from.name') ?? '');
-
-        // Queue diagnostics
-        $queueDefault = (string)(config('queue.default') ?? 'sync');
-        $queueDriver = (string)(config("queue.connections.$queueDefault.driver") ?? '');
-        $queueName = (string)(config("queue.connections.$queueDefault.queue") ?? (string)(config('queue.queue', 'default')));
-
-        return [
-            'default' => $default,
-            'transport' => $transport,
-            'host' => $host,
-            'port' => $port,
-            'encryption' => $encryption,
-            'username' => $username,
-            'from_address' => $fromAddress,
-            'from_name' => $fromName,
-            'queue_default' => $queueDefault,
-            'queue_driver' => $queueDriver,
-            'queue_name' => $queueName,
-        ];
-    }
-
-    protected static function formatMailDiagnosticInfo(array $config): string
-    {
-        $from = trim((string)($config['from_address'] ?? ''));
-        $fromName = trim((string)($config['from_name'] ?? ''));
-        $fromDisplay = $fromName !== '' ? $from . ' (' . $fromName . ')' : $from;
-
-        $parts = [
-            'default=' . (string)($config['default'] ?? ''),
-            'transport=' . (string)($config['transport'] ?? ''),
-            'host=' . (string)($config['host'] ?? ''),
-            'port=' . (string)($config['port'] ?? ''),
-            'encryption=' . (string)($config['encryption'] ?? ''),
-            'username=' . (string)($config['username'] ?? ''),
-            'from=' . $fromDisplay,
-            'queue.default=' . (string)($config['queue_default'] ?? ''),
-            'queue.driver=' . (string)($config['queue_driver'] ?? ''),
-            'queue.name=' . (string)($config['queue_name'] ?? ''),
-        ];
-
-        return implode(' | ', $parts);
-    }
-
-    /**
-     * Probe SMTP connectivity for a host over given ports.
-     * Returns an array: ['host' => string, 'ports' => [port => ['ok' => bool, 'time_ms' => int, 'error' => string|null]]]
-     */
-    protected static function smtpProbe(string $host, array $ports, float $timeoutSeconds = 2.0): array
-    {
-        $result = [
-            'host' => $host,
-            'ports' => [],
-        ];
-
-        $ports = array_values(array_unique(array_filter(array_map('intval', $ports), fn($p) => $p > 0)));
-
-        foreach ($ports as $port) {
-            $start = microtime(true);
-            $ok = false;
-            $error = null;
-
-            try {
-                $remote = sprintf('tcp://%s:%d', $host, $port);
-                $context = stream_context_create([
-                    'socket' => [
-                        'tcp_nodelay' => true,
-                    ],
-                ]);
-                $errno = 0;
-                $errstr = '';
-                $fp = @stream_socket_client($remote, $errno, $errstr, $timeoutSeconds, STREAM_CLIENT_CONNECT, $context);
-                if ($fp !== false) {
-                    $ok = true;
-                    fclose($fp);
-                } else {
-                    $ok = false;
-                    $error = $errstr !== '' ? $errstr : 'Connection failed';
-                }
-            } catch (\Throwable $e) {
-                $ok = false;
-                $error = $e->getMessage();
-            }
-
-            $timeMs = (int)round((microtime(true) - $start) * 1000);
-
-            $result['ports'][$port] = [
-                'ok' => $ok,
-                'time_ms' => $timeMs,
-                'error' => $ok ? null : $error,
-            ];
-        }
-
-        return $result;
-    }
-
-    /**
-     * Format the probe output for inclusion in a UI message.
-     */
-    protected static function formatProbe(array $probe): string
-    {
-        if (!isset($probe['ports']) || $probe['ports'] === []) {
-            return 'probe: none';
-        }
-
-        $parts = [];
-        foreach ($probe['ports'] as $port => $info) {
-            $status = ($info['ok'] ?? false) ? 'up' : 'down';
-            $lat = isset($info['time_ms']) ? $info['time_ms'] . 'ms' : '';
-            $extra = '';
-            if (!($info['ok'] ?? false) && !empty($info['error'])) {
-                $extra = '(' . strtok((string)$info['error'], "\n") . ')';
-            }
-            $parts[] = $port . '=' . $status . ($lat !== '' ? '(' . $lat . ')' : '') . ($extra !== '' ? ' ' . $extra : '');
-        }
-
-        return 'probe: ' . implode(' ', $parts);
-    }
-
-    /**
-     * Provide human hints for typical SendGrid SMTP configuration.
-     */
-    protected static function buildMailHints(array $config, array $probe): string
-    {
-        $host = (string)($config['host'] ?? '');
-        $port = (int)($config['port'] ?? 0);
-        $encryption = trim((string)($config['encryption'] ?? ''));
-
-        $hints = [];
-        if ($host !== '' && str_contains($host, 'sendgrid.net')) {
-            // Recommend TLS on 587/2525, SSL on 465
-            if (in_array($port, [587, 2525], true) && $encryption === '') {
-                $hints[] = 'Hint: For SendGrid on port ' . $port . ', set MAIL_ENCRYPTION=tls.';
-            }
-            if ($port === 465 && !in_array($encryption, ['ssl', 'tls'], true)) {
-                $hints[] = 'Hint: For SendGrid on port 465, set MAIL_ENCRYPTION=ssl.';
-            }
-            // Username must be literally "apikey"
-            if ((string)($config['username'] ?? '') !== 'apikey') {
-                $hints[] = 'Hint: SendGrid SMTP username must be literally "apikey" and password your API key.';
-            }
-        }
-
-        // If configured port is down but another common port is up, suggest switching.
-        $ports = $probe['ports'] ?? [];
-        if ($port > 0 && isset($ports[$port]) && ($ports[$port]['ok'] ?? false) === false) {
-            foreach ([2525, 587, 465] as $alt) {
-                if ($alt !== $port && isset($ports[$alt]) && ($ports[$alt]['ok'] ?? false) === true) {
-                    $suggestEnc = in_array($alt, [587, 2525], true) ? 'tls' : 'ssl';
-                    $hints[] = 'Hint: Port ' . $port . ' seems unreachable, but ' . $alt . ' is reachable. Try MAIL_PORT=' . $alt . ' and MAIL_ENCRYPTION=' . $suggestEnc . '.';
-                    break;
-                }
-            }
-        }
-
-        return implode(' ', $hints);
     }
 }

--- a/app/Notifications/UserMessageNotification.php
+++ b/app/Notifications/UserMessageNotification.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\User;
+use Filament\Notifications\Notification as FilamentNotification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+/**
+ * Generic user message notification supporting mail and database channels.
+ */
+class UserMessageNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * @param array<int, string> $channels e.g. ['mail'] or ['database']
+     */
+    public function __construct(
+        public readonly string $subject,
+        public readonly string $body,
+        public readonly array  $channels = ['database'],
+    )
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return $this->channels;
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $name = property_exists($notifiable, 'name') ? (string)$notifiable->name : '';
+        $appName = (string)config('app.name');
+
+        return (new MailMessage)
+            ->subject($this->subject)
+            ->view('mail.user-message', [
+                'name' => $name,
+                'appName' => $appName,
+                'html' => $this->body,
+                'subject' => $this->subject,
+            ]);
+    }
+
+    public function toDatabase(User $notifiable): array
+    {
+        return FilamentNotification::make()
+            ->title($this->subject)
+            ->body($this->body)
+            ->getDatabaseMessage();
+    }
+
+    /**
+     * Payload saved to the notifications table for the database channel.
+     *
+     * @return array{subject:string,body:string}
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'subject' => $this->subject,
+            'body' => $this->body,
+        ];
+    }
+}

--- a/resources/views/mail/user-message.blade.php
+++ b/resources/views/mail/user-message.blade.php
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ $subject ?? 'Message' }}</title>
+    <style>
+        body {
+            font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+            line-height: 1.5;
+            color: #0f172a;
+            background: #f8fafc;
+        }
+
+        .container {
+            max-width: 640px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .card {
+            background: #ffffff;
+            border: 1px solid #e5e7eb;
+            border-radius: 8px;
+            padding: 24px;
+        }
+
+        .footer {
+            margin-top: 24px;
+            color: #64748b;
+            font-size: 12px;
+        }
+
+        a {
+            color: #2563eb;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="card">
+        <p style="margin-top: 0;">{{ ($name ?? '') !== '' ? 'Hello ' . $name . ',' : 'Hello,' }}</p>
+
+        <div>{!! str($html ?? '')->sanitizeHtml() !!}</div>
+
+        <p>Regards,<br>{{ $appName ?? config('app.name') }}</p>
+    </div>
+    <div class="footer">
+        <p>This message was sent by {{ $appName ?? config('app.name') }}.</p>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
- Introduce actions for sending database notifications and emails to users.
- Create `UserMessageNotification` for multi-channel notifications.
- Add `user-message` email template with dynamic subject and sanitized content.
- Replace `TestMailNotification` with improved user messaging functionality.